### PR TITLE
JSSEngine - ALPN Support

### DIFF
--- a/lib/jss.map
+++ b/lib/jss.map
@@ -472,6 +472,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRequireAlways;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireFirstHandshake;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireNoError;
 Java_org_mozilla_jss_nss_SSL_KeyUpdate;
+Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg;
     local:
         *;
 };

--- a/lib/jss.map
+++ b/lib/jss.map
@@ -473,6 +473,7 @@ Java_org_mozilla_jss_nss_SSL_getSSLRequireFirstHandshake;
 Java_org_mozilla_jss_nss_SSL_getSSLRequireNoError;
 Java_org_mozilla_jss_nss_SSL_KeyUpdate;
 Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg;
+Java_org_mozilla_jss_nss_SSL_GetNextProto;
     local:
         *;
 };

--- a/org/mozilla/jss/nss/NextProtoResult.java
+++ b/org/mozilla/jss/nss/NextProtoResult.java
@@ -1,0 +1,39 @@
+package org.mozilla.jss.nss;
+
+import java.lang.StringBuilder;
+import java.util.Arrays;
+
+import org.mozilla.jss.ssl.SSLNextProtoState;
+
+/**
+ * The fields in the NextProtoResult indicate whether a given SSL-enabled
+ * PRFileDesc has negotiated a next protocol (via ALPN) and if so, what it
+ * is.
+ *
+ * These object is returned by org.mozilla.jss.nss.SSL.GetNextProto(fd).
+ */
+public class NextProtoResult {
+    public SSLNextProtoState state;
+    public byte[] protocol;
+
+    public NextProtoResult(int state_value, byte[] protocol) {
+        state = SSLNextProtoState.valueOf(state_value);
+        this.protocol = protocol;
+    }
+
+    public String getProtocol() {
+        if (protocol == null) {
+            return null;
+        }
+
+        return new String(protocol);
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("State: " + state + "\n");
+        sb.append("Protocol: " + getProtocol() + " ");
+        sb.append(Arrays.toString(protocol) + "\n");
+        return sb.toString();
+    }
+}

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -136,6 +136,40 @@ finish:
     return result;
 }
 
+jobject JSS_NewNextProtoResult(JNIEnv *env, int state, uint8_t *proto,
+    unsigned int proto_len)
+{
+    jclass resultClass;
+    jmethodID constructor;
+    jobject result = NULL;
+    jbyteArray protocol = NULL;
+
+    PR_ASSERT(env != NULL);
+
+    resultClass = (*env)->FindClass(env, NEXT_PROTO_CLASS_NAME);
+    if (resultClass == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    constructor = (*env)->GetMethodID(env, resultClass, PLAIN_CONSTRUCTOR,
+        NEXT_PROTO_CONSTRUCTOR_SIG);
+    if (constructor == NULL) {
+        ASSERT_OUTOFMEM(env);
+        goto finish;
+    }
+
+    if (proto != NULL) {
+        protocol = JSS_ToByteArray(env, proto, proto_len);
+    }
+
+    result = (*env)->NewObject(env, resultClass, constructor, state,
+                               protocol);
+
+finish:
+    return result;
+}
+
 JNIEXPORT jobject JNICALL
 Java_org_mozilla_jss_nss_SSL_ImportFD(JNIEnv *env, jclass clazz, jobject model,
     jobject fd)
@@ -824,6 +858,31 @@ Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg(JNIEnv *env, jclass clazz,
     free(data);
 
     return ret;
+}
+
+JNIEXPORT jobject JNICALL
+Java_org_mozilla_jss_nss_SSL_GetNextProto(JNIEnv *env, jclass clazz,
+    jobject fd)
+{
+    PRFileDesc *real_fd = NULL;
+    SSLNextProtoState state;
+    uint8_t proto[512] = {0};
+    unsigned int proto_len;
+    SECStatus ret;
+
+    PR_ASSERT(env != NULL && fd != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return NULL;
+    }
+
+    ret = SSL_GetNextProto(real_fd, &state, proto, &proto_len,
+                           sizeof(proto));
+    if (ret != SECSuccess) {
+        return JSS_NewNextProtoResult(env, state, NULL, 0);
+    }
+    return JSS_NewNextProtoResult(env, state, proto, proto_len);
 }
 
 JNIEXPORT jint JNICALL

--- a/org/mozilla/jss/nss/SSL.c
+++ b/org/mozilla/jss/nss/SSL.c
@@ -801,6 +801,32 @@ Java_org_mozilla_jss_nss_SSL_KeyUpdate(JNIEnv *env, jclass clazz,
 }
 
 JNIEXPORT jint JNICALL
+Java_org_mozilla_jss_nss_SSL_SetNextProtoNeg(JNIEnv *env, jclass clazz,
+    jobject fd, jbyteArray wire_data)
+{
+    PRFileDesc *real_fd = NULL;
+    uint8_t *data = NULL;
+    size_t data_length = 0;
+    SECStatus ret = SECFailure;
+
+    PR_ASSERT(env != NULL && fd != NULL && wire_data != NULL);
+    PR_SetError(0, 0);
+
+    if (JSS_PR_getPRFileDesc(env, fd, &real_fd) != PR_SUCCESS) {
+        return ret;
+    }
+
+    if (!JSS_FromByteArray(env, wire_data, &data, &data_length)) {
+        return ret;
+    }
+
+    ret = SSL_SetNextProtoNego(real_fd, data, data_length);
+    free(data);
+
+    return ret;
+}
+
+JNIEXPORT jint JNICALL
 Java_org_mozilla_jss_nss_SSL_AttachClientCertCallback(JNIEnv *env, jclass clazz,
     jobject fd)
 {

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -395,6 +395,13 @@ public class SSL {
     public static native int KeyUpdate(SSLFDProxy fd, boolean requestUpdate);
 
     /**
+     * Sets the next protocol negotiation (ALPN) in wire format.
+     *
+     * See also: SSL_SetNextProtoNego in /usr/include/nss3/ssl.h.
+     */
+    public static native int SetNextProtoNeg(SSLFDProxy fd, byte[] wire_data);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/nss/SSL.java
+++ b/org/mozilla/jss/nss/SSL.java
@@ -402,6 +402,13 @@ public class SSL {
     public static native int SetNextProtoNeg(SSLFDProxy fd, byte[] wire_data);
 
     /**
+     * Gets the next negotiated protocol.
+     *
+     * See also: SSL_GetNextProto in /usr/include/nss3/ssl.h.
+     */
+    public static native NextProtoResult GetNextProto(SSLFDProxy fd);
+
+    /**
      * Use client authentication; set client certificate from SSLFDProxy.
      *
      * See also: SSL_GetClientAuthDataHook in /usr/include/nss3/ssl.h,

--- a/org/mozilla/jss/ssl/SSLNextProtoState.java
+++ b/org/mozilla/jss/ssl/SSLNextProtoState.java
@@ -1,0 +1,29 @@
+package org.mozilla.jss.ssl;
+
+public enum SSLNextProtoState {
+    SSL_NEXT_PROTO_NO_SUPPORT (0),
+    SSL_NEXT_PROTO_NEGOTIATED (1),
+    SSL_NEXT_PROTO_NO_OVERLAP (2),
+    SSL_NEXT_PROTO_SELECTED (3),
+    SSL_NEXT_PROTO_EARLY_VALUE (4);
+
+    private int value;
+
+    private SSLNextProtoState(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static SSLNextProtoState valueOf(int value) {
+        for (SSLNextProtoState type : SSLNextProtoState.values()) {
+            if (type.value == value) {
+                return type;
+            }
+        }
+
+        return null;
+    }
+}

--- a/org/mozilla/jss/ssl/javax/JSSEngine.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngine.java
@@ -171,6 +171,11 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
     protected HashMap<Integer, Integer> config;
 
     /**
+     * Set of possible application protocols to negotiate.
+     */
+    protected String[] alpn_protocols;
+
+    /**
      * Constructor for a JSSEngine, providing no hints for an internal
      * session reuse strategy and no key.
      *
@@ -330,6 +335,12 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
         // it.
         if (parsed.getHostname() != null) {
             setHostname(parsed.getHostname());
+        }
+
+        // When we have a non-zero number of ALPNs, use them in the
+        // negotiation.
+        if (parsed.getApplicationProtocols() != null) {
+            setApplicationProtocols(parsed.getApplicationProtocols());
         }
     }
 
@@ -851,6 +862,58 @@ public abstract class JSSEngine extends javax.net.ssl.SSLEngine {
      */
     public boolean getWantClientAuth() {
         return want_client_auth;
+    }
+
+    /**
+     * Set a specific list of protocols to negotiate next for ALPN support.
+     */
+    public void setApplicationProtocols(String[] protocols) {
+        alpn_protocols = protocols;
+    }
+
+    /**
+     * Get the most recently negotiated application protocol.
+     *
+     * Note that NSS only allows selection on the initial handshake so
+     * this is implemented via a call to getHandshakeApplicationProtocol().
+     */
+    public String getApplicationProtocol() {
+        return getHandshakeApplicationProtocol();
+    }
+
+    /**
+     * Get the application protocol negotiated during the initial handshake.
+     */
+    public String getHandshakeApplicationProtocol() {
+        if (session == null) {
+            return null;
+        }
+
+        return session.getNextProtocol();
+    }
+
+    /**
+     * Helper method for implementations: encodes ALPN protocols into wire
+     * format (8-bit length prefixed byte encoding).
+     */
+    public byte[] getALPNWireData() {
+        int length = 0;
+        for (String protocol : alpn_protocols) {
+            length += 1 + protocol.getBytes().length;
+        }
+
+        byte[] result = new byte[length];
+        int offset = 0;
+
+        for (String protocol : alpn_protocols) {
+            byte[] p_bytes = protocol.getBytes();
+            result[offset] = (byte) p_bytes.length;
+            offset += 1;
+            System.arraycopy(p_bytes, 0, result, offset, p_bytes.length);
+            offset += p_bytes.length;
+        }
+
+        return result;
     }
 
     /**

--- a/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
+++ b/org/mozilla/jss/ssl/javax/JSSEngineReferenceImpl.java
@@ -219,10 +219,13 @@ public class JSSEngineReferenceImpl extends JSSEngine {
 
         if (alpn_protocols != null) {
             byte[] wire_data = getALPNWireData();
+            if (wire_data == null) {
+                throw new RuntimeException("JSSEngine.init(): ALPN wire data is NULL but alpn_protocols is non-NULL.");
+            }
 
             ret = SSL.SetNextProtoNeg(ssl_fd, wire_data);
-            if (ret == SSL.SECFailure) {
-                throw new RuntimeException("JSSEngine.init(): Unable to set ALPN protocol list.");
+            if (ret != SSL.SECSuccess) {
+                throw new RuntimeException("JSSEngine.init(): Unable to set ALPN protocol list: " + errorText(PR.GetError()) + " " + ret);
             }
         }
     }

--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -3,6 +3,7 @@ package org.mozilla.jss.ssl.javax;
 import javax.net.ssl.*;
 import java.util.*;
 
+import org.mozilla.jss.util.JDKCompat;
 import org.mozilla.jss.ssl.*;
 
 /**
@@ -54,6 +55,11 @@ public class JSSParameters extends SSLParameters {
         }
         if (downcast.getNeedClientAuth()) {
             setNeedClientAuth(downcast.getNeedClientAuth());
+        }
+
+        String[] alpn = JDKCompat.SSLParametersHelper.getApplicationProtocols(downcast);
+        if (alpn != null) {
+            setApplicationProtocols(alpn);
         }
     }
 

--- a/org/mozilla/jss/ssl/javax/JSSParameters.java
+++ b/org/mozilla/jss/ssl/javax/JSSParameters.java
@@ -26,6 +26,7 @@ public class JSSParameters extends SSLParameters {
     private SSLVersionRange range;
     private String alias;
     private String hostname;
+    private String[] appProtocols;
 
     public JSSParameters() {
         // Choose our default set of SSLParameters here; default to null
@@ -189,5 +190,28 @@ public class JSSParameters extends SSLParameters {
 
     public void setHostname(String server_hostname) {
         hostname = server_hostname;
+    }
+
+    public void setApplicationProtocols(String[] protocols) throws IllegalArgumentException {
+        if (protocols == null) {
+            appProtocols = null;
+            return;
+        }
+
+        int index = 0;
+        for (String protocol : protocols) {
+            if (protocol.length() > 255 || protocol.getBytes().length > 255) {
+                String msg = "Invalid application protocol " + protocol;
+                msg += ": standard allows up to 255 characters but was ";
+                msg += protocol.length();
+                throw new IllegalArgumentException(msg);
+            }
+        }
+
+        appProtocols = protocols;
+    }
+
+    public String[] getApplicationProtocols() {
+        return appProtocols;
     }
 }

--- a/org/mozilla/jss/ssl/javax/JSSSession.java
+++ b/org/mozilla/jss/ssl/javax/JSSSession.java
@@ -37,6 +37,8 @@ public class JSSSession implements SSLSession {
     private X509Certificate[] peerChain;
     private Certificate[] peerCertificates;
 
+    private String nextProtocol;
+
     protected JSSSession(JSSEngine engine, int buffer_size) {
         this.parent = engine;
 
@@ -271,5 +273,13 @@ public class JSSSession implements SSLSession {
 
     public void setPeerPort(int port) {
         peerPort = port;
+    }
+
+    public void setNextProtocol(String protocol) {
+        nextProtocol = protocol;
+    }
+
+    public String getNextProtocol() {
+        return nextProtocol;
     }
 }

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -689,6 +689,20 @@ public class TestSSLEngine {
         testJSSEToJSSHandshakes(ctx, server_alias);
     }
 
+    public static void testALPNEncoding() throws Exception {
+        JSSEngine eng = new JSSEngineReferenceImpl();
+
+        eng.setApplicationProtocols(new String[] { "http/1.1" });
+        byte[] expectedHTTPOnly = new byte[] { 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31 };
+        assert Arrays.equals(eng.getALPNWireData(), expectedHTTPOnly);
+
+        eng = new JSSEngineReferenceImpl();
+
+        eng.setApplicationProtocols(new String[] { "http/1.1", "spdy/2" });
+        byte[] expectedHTTPSpdy = new byte[] { 0x08, 0x68, 0x74, 0x74, 0x70, 0x2f, 0x31, 0x2e, 0x31, 0x06, 0x73, 0x70, 0x64, 0x79, 0x2f, 0x32 };
+        assert Arrays.equals(eng.getALPNWireData(), expectedHTTPSpdy);
+    }
+
     public static void main(String[] args) throws Exception {
         // Args:
         //  - nssdb
@@ -709,5 +723,8 @@ public class TestSSLEngine {
 
         System.out.println("Testing basic handshake with native TM...");
         testNativeClientServer(args);
+
+        System.out.println("Testing ALPN encoding...");
+        testALPNEncoding();
     }
 }

--- a/org/mozilla/jss/tests/TestSSLEngine.java
+++ b/org/mozilla/jss/tests/TestSSLEngine.java
@@ -664,6 +664,38 @@ public class TestSSLEngine {
         }
     }
 
+    public static void testALPNHandshake(SSLContext ctx, String server_alias) throws Exception {
+        JSSEngine client_eng = (JSSEngine) ctx.createSSLEngine();
+        JSSParameters client_params = createParameters();
+        client_params.setApplicationProtocols(new String[] { "http/1.1", "h2", "spdy/2" });
+        client_eng.setSSLParameters(client_params);
+        client_eng.setUseClientMode(true);
+
+        if (client_eng instanceof JSSEngineReferenceImpl) {
+            ((JSSEngineReferenceImpl) client_eng).setName("JSS Client for ALPN");
+        }
+
+        JSSEngine server_eng = (JSSEngine) ctx.createSSLEngine();
+        JSSParameters server_params = createParameters(server_alias);
+        server_params.setApplicationProtocols(new String[] { "h2" });
+        server_eng.setSSLParameters(server_params);
+        server_eng.setUseClientMode(false);
+
+        if (server_eng instanceof JSSEngineReferenceImpl) {
+            ((JSSEngineReferenceImpl) server_eng).setName("JSS Server for ALPN");
+            ((JSSEngineReferenceImpl) server_eng).enableSafeDebugLogging(7377);
+        }
+
+        try {
+            testBasicHandshake(client_eng, server_eng, false);
+            assert(server_eng.getApplicationProtocol().equals("h2"));
+        } catch (Exception e) {
+            client_eng.cleanup();
+            server_eng.cleanup();
+            throw e;
+        }
+    }
+
     public static void testBasicClientServer(String[] args) throws Exception {
         SSLContext ctx = SSLContext.getInstance("TLS", "Mozilla-JSS");
         ctx.init(getKMs(), getTMs(), null);
@@ -687,6 +719,7 @@ public class TestSSLEngine {
         testAllHandshakes(ctx, client_alias, server_alias, true);
         testPostHandshakeAuth(ctx, client_alias, server_alias);
         testJSSEToJSSHandshakes(ctx, server_alias);
+        testALPNHandshake(ctx, server_alias);
     }
 
     public static void testALPNEncoding() throws Exception {

--- a/org/mozilla/jss/util/JDKCompat.java
+++ b/org/mozilla/jss/util/JDKCompat.java
@@ -1,0 +1,21 @@
+package org.mozilla.jss.util;
+
+import java.lang.reflect.Method;
+
+import javax.net.ssl.SSLParameters;
+
+public class JDKCompat {
+    public static class SSLParametersHelper {
+        public static String[] getApplicationProtocols(SSLParameters inst) {
+            try {
+                Method getter = inst.getClass().getMethod("getApplicationProtocols");
+                Object result = getter.invoke(inst);
+                if (result instanceof String[]) {
+                    return (String[]) result;
+                }
+            } catch (Throwable t) {}
+
+            return null;
+        }
+    }
+}

--- a/org/mozilla/jss/util/java_ids.h
+++ b/org/mozilla/jss/util/java_ids.h
@@ -444,6 +444,12 @@ PR_BEGIN_EXTERN_C
 #define SSL_PRELIMINARY_CHANNEL_INFO_CLASS_NAME "org/mozilla/jss/nss/SSLPreliminaryChannelInfo"
 #define SSL_PRELIMINARY_CHANNEL_INFO_CONSTRUCTOR_SIG "(JIIZJZIZZII)V"
 
+/*
+ * NextProtoResult classes
+ */
+#define NEXT_PROTO_CLASS_NAME "org/mozilla/jss/nss/NextProtoResult"
+#define NEXT_PROTO_CONSTRUCTOR_SIG "(I[B)V"
+
 PR_END_EXTERN_C
 
 #endif


### PR DESCRIPTION
This pull request enables ALPN support for JSSEngine, compatible with the JDK9 interface.

ALPN is a method of negotiating the next protocol after TLS. Most of the time this will be `http/1.1`, but could be `h2` or `spdy/2` depending on browser and server support. Without this, Tomcat is limited to `http/1.1` and cannot speak `http/2`.

TODO:
 - [x] Stub ALPN support
 - [x] Implement ALPN with fixed protocol list
 - [ ] Implement ALPN with bifunction selector
 - [x] Test ALPN support
 - [ ] Support JDK8 + JDK9 SSLParameters via reflection